### PR TITLE
docs: add slack-digest to plugin skill list

### DIFF
--- a/technologies/claude.md
+++ b/technologies/claude.md
@@ -29,6 +29,7 @@ This provides:
 - `/pixelfuel:parallel-dev <task1> [task2]` — spin up parallel isolated development sessions
 - `/pixelfuel:build-skill <name>` — guided authoring of a new company skill, committed to a branch and submitted for admin review
 - `/pixelfuel:project-check [--fix]` — audit a repo against company coding standards, report gaps; `--fix` creates a branch with automated corrections
+- `/pixelfuel:slack-digest [--hours n] [--mentions]` — summarize recent Slack activity, surface action items, and flag unanswered threads
 
 Source: [havilandsoftware/pixelfuel-claude](https://github.com/havilandsoftware/pixelfuel-claude)
 


### PR DESCRIPTION
## Summary

- Adds `/pixelfuel:slack-digest` to the company plugin skills list in `technologies/claude.md`

Companion to havilandsoftware/pixelfuel-claude#15.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)